### PR TITLE
Replaces __proto__ assignment with Object.create calls

### DIFF
--- a/vendor/assets/javascripts/paloma/controller_class_factory.js
+++ b/vendor/assets/javascripts/paloma/controller_class_factory.js
@@ -23,7 +23,7 @@ Paloma.ControllerClassFactory.prototype = {
     if (!parent) return;
 
     var parentClass = this.get(parent);
-    if (parentClass) controller.prototype.__proto__ = parentClass.prototype;
+    if (parentClass) controller.prototype = Object.create(parentClass.prototype, controller.prototype);
   },
 
   _updatePrototype: function(controller, newPrototype){
@@ -41,7 +41,8 @@ Paloma.ControllerClassFactory.prototype = {
       Paloma.BaseController.call(this, params);
     };
 
-    controller.prototype.__proto__ = Paloma.BaseController.prototype;
+    controller.prototype = Object.create(Paloma.BaseController.prototype);
+    controller.prototype.constructor = controller;
 
     this._controllers[name] = controller;
     return controller;


### PR DESCRIPTION
This replaces the deprecated setting of Object.prototype.proto with calls to Object.create, implementing classical inheritance as described in the examples here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create

This fixes https://github.com/kbparagua/paloma/issues/98.