### PR TITLE
Remove redundant prepend_view_path

### DIFF
--- a/lib/paloma/action_controller_extension.rb
+++ b/lib/paloma/action_controller_extension.rb
@@ -9,8 +9,6 @@ module Paloma
 
 
       base.module_eval do
-        prepend_view_path "#{Paloma.root}/app/views/"
-
         before_action :track_paloma_request
         helper_method :insert_paloma_hook
       end


### PR DESCRIPTION
prepend_view_path is already called by the Rails::Engine initializer
:add_view_paths, so calling it again duplicates the gem's view path in
the controller's view_paths.

REFERENCES
	- https://github.com/rails/rails/blob/7bede102d2fb279204665cb5c80249eace486021/railties/lib/rails/engine.rb#L592