### PR TITLE
Don't remove the paloma hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ end
 ```
 
 ## Hook
-`insert_paloma_hook` is a helper method that you use in your views to insert Paloma's HTML hook. It is what connects your ruby code to your javascript code. Basically, it contains a javascript code that has embedded ruby in it. That javascript code will register the Rails controller and action to Paloma's engine, then after that it will remove itself from the DOM.
+`insert_paloma_hook` is a helper method that you use in your views to insert Paloma's HTML hook. It is what connects your ruby code to your javascript code. Basically, it contains a javascript code that has embedded ruby in it. That javascript code will register the Rails controller and action to Paloma's engine.
 
 Ideally, you just need to call `insert_paloma_hook` in your layouts, since the layout will always be included in every rendered view. But if you are rendering a view without a layout, make sure to call `insert_paloma_hook` in that view.
 

--- a/app/views/paloma/_hook.html.erb
+++ b/app/views/paloma/_hook.html.erb
@@ -17,9 +17,6 @@
         params: request.params
       });
 
-      var self  = document.querySelector("[data-palomaid='" + id + "']");
-      if (self) self.parentNode.removeChild(self);
-
     })();
   </script>
 </div>


### PR DESCRIPTION
This allows one to re-run the controller code via turbolinks on page re-visit.

Fixes: #6 

Otherwise, this part of the readme is a bit misleading:

> 
> ### Execute Paloma when user hits `Back` or `Forward` button.
> 
> Paloma executes page-specific javascript by adding a `<script>` tag to the response body. Turbolinks, by default, executes any inline javascript in the response body when you visit a page, so the `<script>` tag appended by Paloma will automatically be executed. However, when Turbolinks restores a page from cache (*this happens when a user hits `Back` or `Forward` button in his browser*) any **inline javascript will not be executed** anymore. This is the intentional behavior of Turbolinks, and it is not a bug. If you want to execute Paloma again when Turbolinks restores a page, do something like this:
> 
> ```js
> $(document).on('page:restore', function(){
>   Paloma.start();
> });
> ```

as there is nothing there in the page to re-initialise since Turbolinks caches the page on page transition.

As a side note I wondered if it would be a good idea to include the concept of teardown into Paloma controllers? Rather than just defining a function for the controller action, allow it to be defined as an object with the keys `setup` and `teardown`. Paloma could execute the teardown somehow when the page transitions. This requires a bit more integration with Turbolinks though. Might not be worth the effort.