### PR TITLE
Add test helper module

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,39 @@ end
 
 Ideally, you just need to call `insert_paloma_hook` in your layouts, since the layout will always be included in every rendered view. But if you are rendering a view without a layout, make sure to call `insert_paloma_hook` in that view.
 
+## Testing
+
+A helper module `Paloma::TestHelper` is provided to help with testing parameters passed to javascript in a controller test.
+This module exposes a `js_params` method which returns the set of parameters passed to paloma, which you can then make assertions on.
+
+For example:
+```ruby
+class UsersController
+  def show
+    user = User.find params[:id]
+
+    js :id => user.id, :myParam => 'test'
+  end
+end
+```
+Corresponding test (Minitest):
+```ruby
+# Require test helper
+require "paloma/test_helper"
+
+class UsersControler < ActiveSupport::TestCase
+  # Include helper to access `js_params` method
+  include Paloma::TestHelper
+
+  test "should get show" do
+    user = User.create!
+    get :show, id: user.id
+    
+    expected_params = { id: user.id, myParam: 'test' }
+    assert_equal(expected_params, js_params)
+  end
+end
+```
 
 ## Starting Paloma
 Once Paloma's HTML hook is already executed, you can now start Paloma by calling `Paloma.start()` in your javascript code. First, it will execute the HTML hook if not yet executed, then will initialize the correct Paloma controller, execute any before callbacks, and finally execute the correct action if available.

--- a/lib/paloma/action_controller_extension.rb
+++ b/lib/paloma/action_controller_extension.rb
@@ -111,6 +111,8 @@ module Paloma
 
         self.paloma.resource ||= self.default_resource
         self.paloma.action ||= self.default_action
+
+        self.paloma.save_request_history
       end
 
 

--- a/lib/paloma/controller.rb
+++ b/lib/paloma/controller.rb
@@ -3,6 +3,9 @@ module Paloma
 
     attr_accessor :resource, :action, :params
 
+    if ::Rails.env.test?
+      attr_reader :request_history
+    end
 
 
     def initialize
@@ -18,6 +21,12 @@ module Paloma
       true
     end
 
+    def save_request_history
+      if ::Rails.env.test?
+        @request_history ||= []
+        @request_history.push(self.request)
+      end
+    end
 
     def request
       { resource: resource, action: action, params: params }

--- a/lib/paloma/test_helper.rb
+++ b/lib/paloma/test_helper.rb
@@ -1,0 +1,7 @@
+module Paloma
+  module TestHelper
+    def js_params
+      @js_params ||= @controller.send(:paloma).request_history.last[:params]
+    end
+  end
+end


### PR DESCRIPTION
This PR addresses #9 by adding a `paloma/test_helper.rb` file containing a `Paloma::TestHelper` module, which when included in a controller/functional test, gives access to `js_params` method that results in the parameters passed to `js` in the controller.

Example:
```ruby
class UsersController
  def show
    user = User.find params[:id]

    js :id => user.id, :myParam => 'test'
  end
end
```
Corresponding test (Minitest):
```ruby
require "paloma/test_helper"
class UsersControler < ActiveSupport::TestCase
  include Paloma::TestHelper

  test "should get show" do
    user = User.create!
    get :show, id: user.id

    assert_equal({ id: user.id, myParam: 'test' }, js_params)
  end
end
```